### PR TITLE
v0.9.1 Add support SMS flash class 0 with msg_type: 'SMS_FLASH'

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,6 @@
+== 0.9.1
+* Added support for SMS flash class 0, use option msg_type: 'SMS_FLASH' on api.send_message
+
 == 0.9
 * Added message concatenation support. Messages over 160 characters will be split in to multiple messages and the API concat parameter will be set; the concat parameter can also be set manually (Joshua Sierles, Martin Westin)
 

--- a/README.textile
+++ b/README.textile
@@ -27,6 +27,14 @@ To send a message to multiple recipients, simply pass in an array of numbers.
 </code>
 </pre>
 
+10 Sep 2015 - Added support for SMS flash Class 0
+
+<pre>
+<code>
+  api.send_message(['447771234567', '447771234568'], 'Hello from clickatell', msg_type: 'SMS_FLASH')
+</code>
+</pre>
+
 h2. HTTP Proxy
 
 You can configure the library to use a HTTP proxy when communicating with Clickatell.

--- a/lib/clickatell/api.rb
+++ b/lib/clickatell/api.rb
@@ -82,7 +82,7 @@ module Clickatell
     #    :concat - number of concatenations allowed. I.E. how long is a message allowed to be.
     # Returns a new message ID if successful.
     def send_message(recipient, message_text, opts={})
-      valid_options = opts.only(:from, :mo, :callback, :climsgid, :concat, :unicode)
+      valid_options = opts.only(:from, :mo, :callback, :climsgid, :concat, :unicode, :msg_type)
       valid_options.merge!(:req_feat => '48') if valid_options[:from]
       valid_options.merge!(:mo => '1') if opts[:set_mobile_originated]
       valid_options.merge!(:climsgid => opts[:client_message_id]) if opts[:client_message_id]

--- a/lib/clickatell/version.rb
+++ b/lib/clickatell/version.rb
@@ -2,7 +2,7 @@ module Clickatell #:nodoc:
   module VERSION #:nodoc:
     MAJOR = 0
     MINOR = 9
-    TINY  = 0
+    TINY  = 1
 
     STRING = [MAJOR, MINOR, TINY].join('.')
     


### PR DESCRIPTION
add option msg_type: 'SMS_FLASH' on api.send_message
